### PR TITLE
Add skills model and display skills on homepage

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
   def home
     @posts = Blog.all
+    @skills = Skill.all
   end
 
   def about

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,0 +1,2 @@
+class Skill < ApplicationRecord
+end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,8 @@
 <h1>Homepage</h1>
 <p>Find me in app/views/pages/home.html.erb</p>
+
+<h2>Blog Posts</h2>
 <%= @posts.inspect %>
+
+<h2>Skills</h2>
+<%= @skills.inspect %>

--- a/db/migrate/20180920033927_create_skills.rb
+++ b/db/migrate/20180920033927_create_skills.rb
@@ -1,0 +1,10 @@
+class CreateSkills < ActiveRecord::Migration[5.2]
+  def change
+    create_table :skills do |t|
+      t.string :title
+      t.integer :percent_utilized
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_07_035318) do
+ActiveRecord::Schema.define(version: 2018_09_20_033927) do
 
   create_table "blogs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "skills", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.integer "percent_utilized"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/skills.yml
+++ b/test/fixtures/skills.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  percent_utilized: 1
+
+two:
+  title: MyString
+  percent_utilized: 1

--- a/test/models/skill_test.rb
+++ b/test/models/skill_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SkillTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
L52
This one will only deal with the model - it will NOT have any routes, controllers or views
*Note you normally name models as singular, and controllers as plural*

```bash
portfolio5$ rails g model Skill title:string percent_utilized:integer
Running via Spring preloader in process 9495
      invoke  active_record
      create    db/migrate/20180920033927_create_skills.rb
      create    app/models/skill.rb
      invoke    test_unit
      create      test/models/skill_test.rb
      create      test/fixtures/skills.yml
```
- note how lightweight this one is compared to a controller or scaffold generator.
- `app/model/skill.rb` is the main file made, and just has two lines... it's an orm that connects to database.
```ruby
class Skill < ApplicationRecord
end
```

- Now there is also a new migration:
`db/migrate/20180920033927_create_skills.rb`
```ruby
class CreateSkills < ActiveRecord::Migration[5.2]
  def change
    create_table :skills do |t|
      t.string :title
      t.integer :percent_utilized

      t.timestamps
    end
  end
end
```
- but note the schema file is still the same so we gotta migrate
```bash
portfolio5$ rails db:migrate
== 20180920033927 CreateSkills: migrating =====================================
-- create_table(:skills)
   -> 0.0395s
== 20180920033927 CreateSkills: migrated (0.0396s) ============================
```

Now `schema.rb` has been updated:

```ruby
ActiveRecord::Schema.define(version: 2018_09_20_033927) do

  create_table "blogs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
    t.string "title"
    t.text "body"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
  end

  create_table "skills", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
    t.string "title"
    t.integer "percent_utilized"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
  end

end
```

## Now we add to the skills database
The `rails c` command opens a connection straight to the database

In it he will run `Skill.create!` - he uses the bang so that it will throw an error if he gets something wrong - this is good in development, but in production, leave it out, and let if fail silently - implement validation instead.

```ruby
portfolio5$ rails c
irb(main):002:0> Skill.create!(title: "Rails", percent_utilized: 75)
   (0.4ms)  SET NAMES utf8,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
   (0.1ms)  BEGIN
  Skill Create (2.7ms)  INSERT INTO `skills` (`title`, `percent_utilized`, `created_at`, `updated_at`) VALUES ('Rails', 75, '2018-09-20 03:53:27', '2018-09-20 03:53:27')
   (0.4ms)  COMMIT
=> #<Skill id: 1, title: "Rails", percent_utilized: 75, created_at: "2018-09-20 03:53:27", updated_at: "2018-09-20 03:53:27">

irb(main):003:0>
```
I added a few more, so now you can look at them all with `skill.all`

```ruby
irb(main):005:0> Skill.all
  Skill Load (0.3ms)  SELECT  `skills`.* FROM `skills` LIMIT 11
=> #<ActiveRecord::Relation [#<Skill id: 1, title: "Rails", percent_utilized: 75, created_at: "2018-09-20 03:53:27", updated_at: "2018-09-20 03:53:27">, #<Skill id: 2, title: "Python", percent_utilized: 20, created_at: "2018-09-20 04:09:27", updated_at: "2018-09-20 04:09:27">]>
```

- Edited the home page and controller to now include the skills data on the homepage

`pages.controller.rb`
```ruby
class PagesController < ApplicationController
  def home
    @posts = Blog.all
    @skills = Skill.all
  end

  def about
  end

  def contact
  end
end
```

`home.html.erb`
```html
<h1>Homepage</h1>
<p>Find me in app/views/pages/home.html.erb</p>

<h2>Blog Posts</h2>
<%= @posts.inspect %>

<h2>Skills</h2>
<%= @skills.inspect %>
```